### PR TITLE
Fix Vercel build errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -954,4 +954,3 @@ export default function App() {
     </div>
   );
 }
-}

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
 
 :root {
   font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
- Corrected the CSS import order in `src/index.css`. The `@import` statement for Google Fonts was moved before the `@tailwind` directives to comply with CSS standards.
- Removed a superfluous closing brace in `src/App.jsx` that was causing a JSX syntax error.

These changes resolve the build failures encountered during Vercel deployment.