### PR TITLE
This commit fixes an issue where the aspect ratio of images in the do…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -616,9 +616,10 @@ export default function App() {
                   src={img}
                   alt={`物件画像 ${index + 1}`}
                   style={{
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'contain',
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    width: 'auto',
+                    height: 'auto',
                     display: 'block'
                   }}
                 />


### PR DESCRIPTION
…wnloaded report was distorted.

The previous implementation used `object-fit: contain`, which was not fully supported by the `html2canvas` library, causing the distortion during image generation.

The styling has been changed to use `maxWidth: '100%'` and `maxHeight: '100%'`, which is a more robust method for maintaining aspect ratio and is compatible with `html2canvas`. This ensures the downloaded image correctly reflects the on-screen preview.